### PR TITLE
Add task to set permissions on additional config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Role Variables
 | `mqtt_installation_method` | `native` | How to install the service, either `native` or `container`. |
 | `mqtt_directories` | `[see defaults/main.yml]` | Paths for config, data, and logs |
 | `mqtt_config_files` | `[see defaults/main.yml]` |  |
+| `mqtt_extra_config_files` | `[]` | Extra config files to set ower, group, and optionally mode. |
 | `mqtt_touch_files` | `[see defaults/main.yml]` |  |
 | `mqtt_include_dir` | `{{ mqtt_config_dir }}/conf.d` |  |
 | `mqtt_accounts` | `[]` | List of accounts and their hash generated with `mosquitto_passwd` that will have access to the broker. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@ mqtt_installation_method: native
 mqtt_log_file: mosquitto.log
 mqtt_service_name: mosquitto
 
+mqtt_extra_config_files: []
 mqtt_config_files:
   - mosquitto.conf.j2
   - name: passwd.j2

--- a/tasks/container.yml
+++ b/tasks/container.yml
@@ -53,6 +53,18 @@
     - mqtt
     - mqtt_config
 
+- name: Set permissions on additional config files
+  file:
+    path: "{{ item.name | default(item) }}"
+    owner: "{{ mqtt_user }}"
+    group: "{{ mqtt_group }}"
+    mode: "{{ item.mode | default(omit) }}"
+  loop: "{{ mqtt_extra_config_files }}"
+  notify: restart mqtt container
+  tags:
+    - mqtt
+    - mqtt_config
+
 - name: Run MQTT container
   docker_container:
     image: "{{ mqtt_image_name }}"

--- a/tasks/native.yml
+++ b/tasks/native.yml
@@ -28,6 +28,18 @@
     - mqtt
     - mqtt_config
 
+- name: Set permissions on additional config files
+  file:
+    path: "{{ item.name | default(item) }}"
+    owner: "{{ mqtt_user }}"
+    group: "{{ mqtt_group }}"
+    mode: "{{ item.mode | default(omit) }}"
+  loop: "{{ mqtt_extra_config_files }}"
+  notify: restart mqtt
+  tags:
+    - mqtt
+    - mqtt_config
+
 - name: Start and enable mosquitto service
   service:
     name: "{{ mqtt_service_name }}"


### PR DESCRIPTION
Since the user and group needed to own various files is created by this role, it’s not possible to set file permissions easily outside of this role. Add a variable and tasks that will set owner, group, and mode on arbitrary files.

Fixes #7.